### PR TITLE
fix "split screen makes entering code impossible"

### DIFF
--- a/app/src/main/java/com/anyapk/installer/MainActivity.kt
+++ b/app/src/main/java/com/anyapk/installer/MainActivity.kt
@@ -18,6 +18,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var statusText: TextView
     private lateinit var actionButton: Button
+    private lateinit var refreshButton: Button
     private lateinit var testConnectionButton: Button
     private lateinit var selectApkButton: Button
 
@@ -38,11 +39,16 @@ class MainActivity : AppCompatActivity() {
 
         statusText = findViewById(R.id.statusText)
         actionButton = findViewById(R.id.actionButton)
+        refreshButton = findViewById(R.id.refreshButton)
         testConnectionButton = findViewById(R.id.testConnectionButton)
         selectApkButton = findViewById(R.id.selectApkButton)
 
         actionButton.setOnClickListener {
             showPairingDialog()
+        }
+
+        refreshButton.setOnClickListener {
+            checkStatus()
         }
 
         testConnectionButton.setOnClickListener {
@@ -73,6 +79,7 @@ class MainActivity : AppCompatActivity() {
                     actionButton.isEnabled = false
                     actionButton.text = getString(R.string.btn_connected)
                     testConnectionButton.visibility = Button.GONE
+                    refreshButton.visibility = Button.GONE
                     selectApkButton.visibility = Button.VISIBLE
                 }
                 else -> {

--- a/app/src/main/java/com/anyapk/installer/PairingDialogFragment.kt
+++ b/app/src/main/java/com/anyapk/installer/PairingDialogFragment.kt
@@ -18,7 +18,7 @@ class PairingDialogFragment : DialogFragment() {
 
         return AlertDialog.Builder(requireContext())
             .setTitle(getString(R.string.pairing_title))
-            .setMessage(getString(R.string.pairing_message))
+            //.setMessage(getString(R.string.pairing_message))
             .setView(view)
             .setPositiveButton(getString(R.string.btn_pair)) { _, _ ->
                 val code = codeInput.text.toString()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,13 +16,26 @@
         android:layout_marginBottom="32dp"
         android:lineSpacingExtra="4dp" />
 
-    <Button
-        android:id="@+id/actionButton"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/btn_waiting"
-        android:minWidth="200dp"
-        android:layout_marginBottom="16dp" />
+        android:orientation="horizontal">
+        <Button
+            android:id="@+id/actionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_waiting"
+            android:minWidth="200dp"
+            android:layout_marginBottom="16dp" />
+
+        <Button
+            android:id="@+id/refreshButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_refresh"
+            android:minWidth="200dp"
+            android:layout_marginBottom="16dp" />
+    </LinearLayout>
 
     <Button
         android:id="@+id/testConnectionButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="pairing_success">✅ Paired successfully!</string>
     <string name="pairing_failed">❌ Pairing failed: %s</string>
     <string name="btn_select_apk">Select APK to Install</string>
+    <string name="btn_refresh">Refresh</string>
 </resources>


### PR DESCRIPTION
the message in the alert box takes too much space and therefore the values cannot be entered.
The instructions are already shown on the screen before, so we do not need them.
In addition this adds a Refresh button because after successful pairing the status is not updated automatically.

Probably there will be better fixes in future but with these changes it is working well :-)