### PR TITLE
Remove PR

### DIFF
--- a/.github/workflow/build-app.yaml
+++ b/.github/workflow/build-app.yaml
@@ -1,0 +1,65 @@
+name: 🏗️ Build & Release APK
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 🔨 Build APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v5
+
+      - name: ☕ Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: 💾 Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper/
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: 🔑 Setup keystore
+        run: |
+          mkdir -p app
+          echo "${{ secrets.KEYSTORE }}" | base64 -d > app/anyapk-release.keystore
+
+      - name: 🏭 Build Release APK
+        run: |
+          cd app
+          ../gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=anyapk-release.keystore \
+            -Pandroid.injected.signing.store.password="${{ secrets.KEYSTORE_PASSWORD }}" \
+            -Pandroid.injected.signing.key.alias="${{ secrets.KEY_ALIAS }}" \
+            -Pandroid.injected.signing.key.password="${{ secrets.KEY_PASSWORD }}" \
+            --no-daemon
+
+      - name: 📝 Extract versionName
+        id: get_version
+        run: |
+          VERSION_NAME=$(grep 'versionName =' app/build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+
+      - name: 📦 Create GitHub Release & upload APK
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "AnyAPK v${{ env.VERSION_NAME }}"
+          body: "📱 Automated release of AnyAPK"
+          draft: false
+          prerelease: false
+          files: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
Adding Android Keystore Secrets to GitHub

To sign your Android APKs in GitHub Actions, you need to store your keystore and related passwords as GitHub secrets. Follow these steps:

| Secret Name         | Description                                         |
|--------------------|-----------------------------------------------------|
| `KEYSTORE`          | Content of the keystore file encoded in base64.    |
| `KEYSTORE_PASSWORD` | Password for the keystore.                         |
| `KEY_ALIAS`         | Alias of the signing key inside the keystore.      |
| `KEY_PASSWORD`      | Password of the signing key.                       |


Step 1: Generate the Keystore
Use keytool to create your keystore:
```bash
keytool -genkey -v -keystore anyapk-release.keystore -alias anyapk -keyalg RSA -keysize 2048 -validity 10000
```

Step 2: Encode Keystore as Base64
```bash
base64 -i anyapk-release.keystore -o anyapk-release.keystore.base64
```bash
Copy the contents of anyapk-release.keystore.base64 — you will use this for the GitHub secret KEYSTORE.