### PR TITLE
Autodetect port with AdbMdns library from Shizuku

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Your activity is your business, not ours.
 ## License
 
 This project is open source under the Apache 2.0 license. Use it, modify it, share it. Free software for free people.
+It uses AdbMdns class from [Shizuku](https://github.com/RikkaApps/Shizuku/blob/master/manager/src/main/java/moe/shizuku/manager/adb/AdbMdns.kt), published under Apache 2.0 license.
 
 ## Contributing
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "com.anyapk.installer"
-        minSdk = 23
+        minSdk = 30
         targetSdk = 34
         versionCode = 5
         versionName = "0.0.5"

--- a/app/src/main/java/com/anyapk/installer/AdbMdns.kt
+++ b/app/src/main/java/com/anyapk/installer/AdbMdns.kt
@@ -1,0 +1,131 @@
+package com.anyapk.installer
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.Observer
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.ServerSocket
+
+@RequiresApi(Build.VERSION_CODES.R)
+class AdbMdns(
+    context: Context, private val serviceType: String,
+    private val observer: Observer<Int>
+) {
+
+    private var registered = false
+    private var running = false
+    private var serviceName: String? = null
+    private val listener = DiscoveryListener(this)
+    private val nsdManager: NsdManager = context.getSystemService(NsdManager::class.java)
+
+    fun start() {
+        if (running) return
+        running = true
+        if (!registered) {
+            nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, listener)
+        }
+    }
+
+    fun stop() {
+        if (!running) return
+        running = false
+        if (registered) {
+            nsdManager.stopServiceDiscovery(listener)
+        }
+    }
+
+    private fun onDiscoveryStart() {
+        registered = true
+    }
+
+    private fun onDiscoveryStop() {
+        registered = false
+    }
+
+    private fun onServiceFound(info: NsdServiceInfo) {
+        nsdManager.resolveService(info, ResolveListener(this))
+    }
+
+    private fun onServiceLost(info: NsdServiceInfo) {
+        if (info.serviceName == serviceName) observer.onChanged(-1)
+    }
+
+    private fun onServiceResolved(resolvedService: NsdServiceInfo) {
+        if (running && NetworkInterface.getNetworkInterfaces()
+                .asSequence()
+                .any { networkInterface ->
+                    networkInterface.inetAddresses
+                        .asSequence()
+                        .any { resolvedService.host.hostAddress == it.hostAddress }
+                }
+            && isPortAvailable(resolvedService.port)
+        ) {
+            serviceName = resolvedService.serviceName
+            observer.onChanged(resolvedService.port)
+        }
+    }
+
+    private fun isPortAvailable(port: Int) = try {
+        ServerSocket().use {
+            it.bind(InetSocketAddress("127.0.0.1", port), 1)
+            false
+        }
+    } catch (e: IOException) {
+        true
+    }
+
+    internal class DiscoveryListener(private val adbMdns: AdbMdns) : NsdManager.DiscoveryListener {
+        override fun onDiscoveryStarted(serviceType: String) {
+            Log.v(TAG, "onDiscoveryStarted: $serviceType")
+
+            adbMdns.onDiscoveryStart()
+        }
+
+        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+            Log.v(TAG, "onStartDiscoveryFailed: $serviceType, $errorCode")
+        }
+
+        override fun onDiscoveryStopped(serviceType: String) {
+            Log.v(TAG, "onDiscoveryStopped: $serviceType")
+
+            adbMdns.onDiscoveryStop()
+        }
+
+        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+            Log.v(TAG, "onStopDiscoveryFailed: $serviceType, $errorCode")
+        }
+
+        override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+            Log.v(TAG, "onServiceFound: ${serviceInfo.serviceName}")
+
+            adbMdns.onServiceFound(serviceInfo)
+        }
+
+        override fun onServiceLost(serviceInfo: NsdServiceInfo) {
+            Log.v(TAG, "onServiceLost: ${serviceInfo.serviceName}")
+
+            adbMdns.onServiceLost(serviceInfo)
+        }
+    }
+
+    internal class ResolveListener(private val adbMdns: AdbMdns) : NsdManager.ResolveListener {
+        override fun onResolveFailed(nsdServiceInfo: NsdServiceInfo, i: Int) {}
+
+        override fun onServiceResolved(nsdServiceInfo: NsdServiceInfo) {
+            adbMdns.onServiceResolved(nsdServiceInfo)
+        }
+
+    }
+
+    companion object {
+        const val TLS_CONNECT = "_adb-tls-connect._tcp"
+        const val TLS_PAIRING = "_adb-tls-pairing._tcp"
+        const val TAG = "AdbMdns"
+    }
+}

--- a/app/src/main/java/com/anyapk/installer/MainActivity.kt
+++ b/app/src/main/java/com/anyapk/installer/MainActivity.kt
@@ -213,12 +213,6 @@ class MainActivity : AppCompatActivity() {
                 ).show()
             }
         }
-
-        Toast.makeText(
-            this,
-            "Go to Wireless Debugging, tap 'Pair device', then swipe down and enter the code in the notification",
-            Toast.LENGTH_LONG
-        ).show()
     }
 
     private fun requestNotificationPermission() {

--- a/app/src/main/java/com/anyapk/installer/PairingInputReceiver.kt
+++ b/app/src/main/java/com/anyapk/installer/PairingInputReceiver.kt
@@ -4,6 +4,7 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
@@ -26,29 +27,20 @@ class PairingInputReceiver : BroadcastReceiver() {
             val input = remoteInput.getCharSequence(PairingInputService.KEY_PAIRING_INPUT)?.toString()
 
             if (input.isNullOrEmpty()) {
-                Toast.makeText(context, "Please enter code and port", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "Please enter code", Toast.LENGTH_SHORT).show()
                 return
             }
 
-            // Parse input format: "CODE PORT" (space-separated)
-            val parts = input.trim().split("\\s+".toRegex())
-            if (parts.size != 2) {
-                Toast.makeText(
-                    context,
-                    "Invalid format. Use: CODE PORT (e.g., 123456 37829)",
-                    Toast.LENGTH_LONG
-                ).show()
-                return
-            }
+            val portInt = intent.getIntExtra("PORT_EXTRA", -1)
+            if (portInt == -1) return // Handle error
 
-            val code = parts[0]
-            val portInt = parts[1].toIntOrNull()
+            val code = input.trim()
 
             if (portInt == null || portInt <= 0) {
                 Toast.makeText(context, "Invalid port number", Toast.LENGTH_SHORT).show()
                 return
             }
-
+            Log.i("PairingInputReceiver",code + " " + portInt)
             // Show progress notification
             showProgressNotification(context)
 

--- a/app/src/main/java/com/anyapk/installer/PairingInputService.kt
+++ b/app/src/main/java/com/anyapk/installer/PairingInputService.kt
@@ -8,35 +8,48 @@ import android.app.Service
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.Observer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 
 class PairingInputService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var adbMdns: AdbMdns? = null
+
+    private val observer = Observer<Int> { port ->
+        Log.i("PairingInputService", "Pairing service port: $port")
+        if (port <= 0) return@Observer
+
+        // Since the service could be killed before user finishing input,
+        // we need to put the port into Intent
+        val notification = createPairingNotification(port)
+
+        getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
+    }
 
     override fun onCreate() {
         super.onCreate()
-        startForeground(NOTIFICATION_ID, createPairingNotification())
+        startForeground(NOTIFICATION_ID, createPairingNotification(0))
     }
 
-    private fun createPairingNotification(): Notification {
+    private fun createPairingNotification(port: Int): Notification {
         createNotificationChannel()
 
         // Create single RemoteInput for both code and port
         val remoteInput = RemoteInput.Builder(KEY_PAIRING_INPUT)
-            .setLabel("Code and Port (e.g., 123456 37829)")
+            .setLabel("Code (e.g., 123456)")
             .build()
 
         // Create intent to handle the input
         val replyIntent = Intent(this, PairingInputReceiver::class.java).apply {
             action = ACTION_PAIRING_INPUT
+            putExtra("PORT_EXTRA", port)
         }
 
         val replyPendingIntent = PendingIntent.getBroadcast(
@@ -49,11 +62,13 @@ class PairingInputService : Service() {
         // Create notification with reply action
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentTitle("Enter Pairing Code")
-            .setContentText("Format: CODE PORT (e.g., 123456 37829)")
+            .setContentTitle(if (port == 0) "Tap 'Pair device'"
+                else "Enter Pairing Code")
             .setStyle(NotificationCompat.BigTextStyle()
-                .bigText("Open Settings → Wireless Debugging to see the code and port.\n\nThen tap 'Reply' below and enter: CODE PORT\n\nExample: 123456 37829"))
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .bigText("Open Settings → Wireless Debugging → tap 'Pair device' to see the code.\n\nThen tap 'Reply' below and enter: CODE\n\nExample: 123456"))
+            .setPriority(
+                if (port == 0) NotificationCompat.PRIORITY_MAX
+                else NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
             .addAction(
                 NotificationCompat.Action.Builder(
@@ -82,6 +97,8 @@ class PairingInputService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d("PairingInputService",intent?.action.toString())
+        adbMdns = AdbMdns(this, AdbMdns.TLS_PAIRING, observer).apply { start()}
         return START_STICKY
     }
 
@@ -91,6 +108,7 @@ class PairingInputService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        adbMdns?.stop()
         serviceScope.cancel()
     }
 


### PR DESCRIPTION
Simplifies pairing process.
Requires SDK 30+ however
It uses a libray from Shizuku to automatically detect the port.