### PR TITLE
Shrink the release APK from 24MB to 5MB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,25 @@ jobs:
       - name: Build release APK
         run: ./gradlew --no-daemon assembleRelease
 
-      - name: Stage APK with release name
+      - name: Stage APKs with release names
         run: |
           set -euo pipefail
           mkdir -p release
-          src=$(find app/build/outputs/apk/release -name '*.apk' ! -name '*-unsigned*' | head -n1)
-          dest="release/anyapk${{ matrix.suffix }}-${{ needs.version.outputs.version }}.apk"
-          cp "$src" "$dest"
+          # One APK per ABI plus the universal fallback. UpdateChecker.selectAsset()
+          # matches on the trailing -<abi>.apk, so the suffix here is load-bearing:
+          # renaming these silently breaks in-app updates.
+          shopt -s nullglob
+          staged=0
+          for src in app/build/outputs/apk/release/app-*-release.apk; do
+            case "$src" in *-unsigned*) continue;; esac
+            abi=$(basename "$src"); abi=${abi#app-}; abi=${abi%-release.apk}
+            cp "$src" "release/anyapk${{ matrix.suffix }}-${{ needs.version.outputs.version }}-${abi}.apk"
+            staged=$((staged + 1))
+          done
+          if [ "$staged" -eq 0 ]; then
+            echo "No release APKs were produced" >&2
+            exit 1
+          fi
           ls -la release/
 
       - uses: actions/upload-artifact@v4
@@ -146,5 +158,5 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |
-            release/anyapk-${{ needs.version.outputs.version }}.apk
-            release/anyapk-dev-${{ needs.version.outputs.version }}.apk
+            release/anyapk-${{ needs.version.outputs.version }}-*.apk
+            release/anyapk-dev-${{ needs.version.outputs.version }}-*.apk

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Android devices belong to their users, not corporations or governments. Yet with
 
 anyapk returns control to where it belongs: in your hands.
 
-Learn more about how Google is restricting your freedoms and how you can fight back at [keepandroidopen.org](https://keepandroidopen.org/).
-
 ## Manifesto: Application Freedom
 
 When a corporation becomes a gatekeeper, they don't stand alone at the gate. Their partners become gatekeepers. Government jurisdictions become gatekeepers. And suddenly, what began as a "quality control measure" transforms into a lever of control.
@@ -42,6 +40,8 @@ We built anyapk because we believe:
 
 If you believe software should serve users rather than control them, anyapk is for you.
 
+Anyapk is not a solution to the problem - it's a tool that helps you bypass the problem. A real solution is competent government regulation that protects users from unfair and anti-competitive lockdown practices. Learn more about how Google is restricting your freedoms and how you can fight back at [keepandroidopen.org](https://keepandroidopen.org/).
+
 ## Features
 
 - **One-time setup**: Pair once using wireless debugging, use forever
@@ -58,10 +58,22 @@ If you believe software should serve users rather than control them, anyapk is f
 
 ### Method 1: Install via APK (Recommended)
 
-1. Download the latest `anyapk.apk` from the [Releases](../../releases) page
+1. Download the latest APK from the [Releases](../../releases) page. There is one build per
+   CPU architecture — take `arm64-v8a` unless you know otherwise, since it covers virtually
+   every phone made in the last decade:
+
+   | File | For |
+   | --- | --- |
+   | `anyapk-<version>-arm64-v8a.apk` | Almost all phones and tablets |
+   | `anyapk-<version>-armeabi-v7a.apk` | Older 32-bit devices |
+   | `anyapk-<version>-x86_64.apk` | Emulators, x86 Chromebooks |
+   | `anyapk-<version>-universal.apk` | Works everywhere, roughly twice the size |
+
 2. Open the APK file on your device
 3. Grant installation permissions if prompted
 4. Welcome to application freedom
+
+Once installed, anyapk's self-updater picks the right build for your device on its own.
 
 ### Method 2: Install via ADB (The Last Time)
 
@@ -84,7 +96,7 @@ If you can't install the APK directly (due to existing restrictions), use ADB fr
 
 4. Install anyapk using ADB:
    ```bash
-   adb install anyapk.apk
+   adb install anyapk-<version>-arm64-v8a.apk
    ```
 
 5. You're done! You won't need ADB from your computer again.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,10 @@ android {
         versionName = "0.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // anyapk ships no translations of its own; this drops the ~80 locales that
+        // AppCompat and Material carry for their handful of framework strings.
+        resourceConfigurations += listOf("en")
     }
 
     signingConfigs {
@@ -43,12 +47,42 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
             signingConfig = signingConfigs.getByName("release")
+        }
+    }
+
+    // Conscrypt's libconscrypt_jni.so is ~2 MB per ABI and dominates the download, so
+    // ship one APK per ABI instead of making every user carry all four. The universal
+    // APK stays as the fallback for anyone who does not know which one they need;
+    // UpdateChecker picks the matching asset automatically on upgrade.
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("arm64-v8a", "armeabi-v7a", "x86_64")
+            isUniversalApk = true
+        }
+    }
+
+    packaging {
+        resources {
+            // R8 strips unreachable Bouncy Castle classes but not their Java resources.
+            // libadb only reaches SHA-256, AES-GCM, HKDF and Base64, so the post-quantum
+            // lowmc tables and the cert-path message catalogues are pure dead weight.
+            excludes += listOf(
+                "org/bouncycastle/pqc/**",
+                "org/bouncycastle/x509/CertPathReviewerMessages*.properties",
+                "DebugProbesKt.bin",
+                "META-INF/*.version",
+                "META-INF/**/LICENSE.txt",
+                "kotlin/**",
+            )
         }
     }
 
@@ -79,7 +113,11 @@ dependencies {
     // LibADB Android
     implementation("com.github.MuntashirAkon:libadb-android:3.1.0")
 
-    // Custom Conscrypt (recommended for local ADB)
+    // Custom Conscrypt. Required, not merely recommended: pairing derives the SPAKE2
+    // secret from the TLS exporter, and PairingConnectionCtx.exportKeyingMaterial() only
+    // falls back to com.android.org.conscrypt.Conscrypt when this is absent. That is a
+    // hidden platform class, so the reflective lookup is blocked on Android 11+ and
+    // pairing fails with a correct code. Its size is handled by the ABI split above.
     implementation("org.conscrypt:conscrypt-android:2.5.3")
 
     // For key generation

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,6 +8,18 @@
 # Keep LibADB classes
 -keep class io.github.muntashirakon.adb.** { *; }
 
-# Keep sun security classes for certificate generation
--keep class sun.security.** { *; }
--dontwarn sun.security.**
+# Keep sun security classes for certificate generation.
+#
+# sun-security-android repackages these under android.sun.security, NOT sun.security --
+# the rule has to name the real package or it silently matches nothing. Keeping them is
+# not optional: OIDMap, CertificateExtensions and X509Key resolve extension classes by
+# Class.forName on their fully-qualified names, so obfuscating them breaks the ADB
+# certificate generation in AdbConnectionManager at runtime, not at build time.
+-keep class android.sun.security.** { *; }
+-dontwarn android.sun.security.**
+
+# Conscrypt ships its own keep rules, but its -dontwarn list misses these two. Both are
+# platform-internal classes that only its pre-API-29 compatibility shims reference, so
+# they are absent at compile time and R8 fails the build without this.
+-dontwarn com.android.org.conscrypt.SSLParametersImpl
+-dontwarn org.apache.harmony.xnet.provider.jsse.SSLParametersImpl

--- a/app/src/main/java/com/anyapk/installer/UpdateChecker.kt
+++ b/app/src/main/java/com/anyapk/installer/UpdateChecker.kt
@@ -1,6 +1,7 @@
 package com.anyapk.installer
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -64,16 +65,20 @@ object UpdateChecker {
 
             // Find the APK download URL from assets
             val assets = json.getJSONArray("assets")
-            var apkUrl: String? = null
+            val apkNames = mutableListOf<String>()
+            val urlsByName = mutableMapOf<String, String>()
 
             for (i in 0 until assets.length()) {
                 val asset = assets.getJSONObject(i)
                 val name = asset.getString("name")
                 if (name.endsWith(".apk", ignoreCase = true)) {
-                    apkUrl = asset.getString("browser_download_url")
-                    break
+                    apkNames += name
+                    urlsByName[name] = asset.getString("browser_download_url")
                 }
             }
+
+            val apkUrl = selectAsset(apkNames, currentVersionName, Build.SUPPORTED_ABIS.toList())
+                ?.let { urlsByName[it] }
 
             if (apkUrl == null) {
                 Log.e(TAG, "No APK file found in latest release")
@@ -104,6 +109,34 @@ object UpdateChecker {
             Log.e(TAG, "Error checking for updates", e)
             return@withContext null
         }
+    }
+
+    /**
+     * Picks the release asset this device should install.
+     *
+     * Releases carry one APK per ABI plus a universal fallback, and both a main and a
+     * `-dev` build of each, so "the first .apk in the list" would happily hand an arm64
+     * phone the x86_64 build or cross a user between channels. Assets are named
+     * `anyapk[-dev]-<version>-<abi>.apk`.
+     *
+     * [abis] is [Build.SUPPORTED_ABIS], the device's own preference order, so a 64-bit
+     * phone takes the arm64 build and falls back to the 32-bit one it can also run.
+     * Universal is the last resort.
+     */
+    internal fun selectAsset(
+        names: List<String>,
+        currentVersionName: String,
+        abis: List<String>
+    ): String? {
+        val wantDev = currentVersionName.contains("-dev", ignoreCase = true)
+        val channel = names.filter { it.contains("-dev-", ignoreCase = true) == wantDev }
+            .ifEmpty { return null }
+
+        for (abi in abis) {
+            channel.firstOrNull { it.endsWith("-$abi.apk", ignoreCase = true) }?.let { return it }
+        }
+        return channel.firstOrNull { it.endsWith("-universal.apk", ignoreCase = true) }
+            ?: channel.first()
     }
 
     private fun getCurrentVersionName(context: Context): String {

--- a/app/src/test/java/com/anyapk/installer/UpdateCheckerAssetTest.kt
+++ b/app/src/test/java/com/anyapk/installer/UpdateCheckerAssetTest.kt
@@ -1,0 +1,85 @@
+package com.anyapk.installer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Covers which release asset an update installs.
+ *
+ * Releases carry one APK per ABI plus a universal fallback, in both a main and a `-dev`
+ * flavour, so a release page holds eight APKs that all look alike. Picking the wrong one
+ * hands the user an APK their device cannot run, or silently moves them between
+ * channels; either way the failure only shows up after the download.
+ */
+class UpdateCheckerAssetTest {
+
+    private val release = listOf(
+        "anyapk-0.0.6-arm64-v8a.apk",
+        "anyapk-0.0.6-armeabi-v7a.apk",
+        "anyapk-0.0.6-x86_64.apk",
+        "anyapk-0.0.6-universal.apk",
+        "anyapk-dev-0.0.6-arm64-v8a.apk",
+        "anyapk-dev-0.0.6-armeabi-v7a.apk",
+        "anyapk-dev-0.0.6-x86_64.apk",
+        "anyapk-dev-0.0.6-universal.apk",
+    )
+
+    private fun pick(version: String, vararg abis: String) =
+        UpdateChecker.selectAsset(release, version, abis.toList())
+
+    // -- The device's own ABI order decides ------------------------------------------
+
+    @Test
+    fun `64-bit arm device takes the arm64 build`() {
+        assertEquals("anyapk-0.0.6-arm64-v8a.apk", pick("0.0.5", "arm64-v8a", "armeabi-v7a"))
+    }
+
+    @Test
+    fun `32-bit only device takes the v7a build`() {
+        assertEquals("anyapk-0.0.6-armeabi-v7a.apk", pick("0.0.5", "armeabi-v7a"))
+    }
+
+    @Test
+    fun `x86_64 device is not handed an arm build`() {
+        assertEquals("anyapk-0.0.6-x86_64.apk", pick("0.0.5", "x86_64", "x86"))
+    }
+
+    /** armeabi-v7a is listed first only because the emulator reports it first. */
+    @Test
+    fun `abi preference order is honoured over list order`() {
+        assertEquals("anyapk-0.0.6-armeabi-v7a.apk", pick("0.0.5", "armeabi-v7a", "arm64-v8a"))
+    }
+
+    // -- Channels must not cross ------------------------------------------------------
+
+    @Test
+    fun `dev build stays on the dev channel`() {
+        assertEquals("anyapk-dev-0.0.6-arm64-v8a.apk", pick("0.0.5-dev", "arm64-v8a"))
+    }
+
+    @Test
+    fun `release build is never handed a dev asset`() {
+        val devOnly = release.filter { it.contains("-dev-") }
+        assertNull(UpdateChecker.selectAsset(devOnly, "0.0.5", listOf("arm64-v8a")))
+    }
+
+    // -- Fallbacks --------------------------------------------------------------------
+
+    @Test
+    fun `unknown abi falls back to universal rather than a wrong arch`() {
+        assertEquals("anyapk-0.0.6-universal.apk", pick("0.0.5", "riscv64"))
+    }
+
+    /** Older releases predate the split, so their single asset must still be found. */
+    @Test
+    fun `a release with one unsuffixed apk still resolves`() {
+        val old = listOf("anyapk-0.0.5.apk")
+        assertEquals("anyapk-0.0.5.apk", UpdateChecker.selectAsset(old, "0.0.4", listOf("arm64-v8a")))
+    }
+
+    @Test
+    fun `a release with no apks resolves to nothing`() {
+        assertNull(UpdateChecker.selectAsset(emptyList(), "0.0.5", listOf("arm64-v8a")))
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,13 +250,18 @@
   <section id="install">
     <h2>Install anyapk</h2>
     <p>
-      Download the latest <code>anyapk.apk</code> from the
+      Grab the latest build from the
       <a href="https://github.com/sam1am/anyapk/releases">releases page</a>, open it on your device,
-      and grant installation permission if prompted.
+      and grant installation permission if prompted. There is one build per CPU architecture —
+      take the <code>arm64-v8a</code> one unless you know otherwise, since it covers virtually
+      every phone made in the last decade. The <code>universal</code> build works on anything
+      at roughly twice the size. After that, anyapk updates itself and picks the right build
+      for your device on its own.
     </p>
     <p>
       If your device refuses to install it, use ADB from a computer once —
-      <code>adb install anyapk.apk</code> — and that's the last time you'll need a computer for this.
+      <code>adb install anyapk-&lt;version&gt;-arm64-v8a.apk</code> — and that's the last time
+      you'll need a computer for this.
     </p>
   </section>
 


### PR DESCRIPTION
Fixes #23.

The reporter was right that the size didn't match the functionality — the APK was almost entirely code and data the app never reaches.

| | |
| --- | --- |
| **arm64-v8a** (almost everyone) | **5.08 MB** |
| armeabi-v7a | 4.30 MB |
| x86_64 | 5.47 MB |
| universal (fallback) | 10.97 MB |
| *was* | *24.24 MB* |

## Where the size went

Release builds had `isMinifyEnabled = false`, so **Bouncy Castle shipped whole**: 16.5 MB across four dex files. It arrives transitively via `libadb-android`, which only ever calls SHA-256, AES-GCM, HKDF and Base64 from it — R8 leaves 310 classes. R8 doesn't strip *Java resources*, so the post-quantum `picnic/lowmcL*` tables and cert-path message catalogues (1.3 MB) are excluded explicitly. anyapk ships no translations of its own, so the locale filter drops the ~80 that AppCompat and Material carry, taking `resources.arsc` from 985 KB to 530 KB.

That gets everything except native code to 3 MB, which leaves Conscrypt's `libconscrypt_jni.so` as the bulk of the download at ~2 MB per ABI — hence one APK per ABI plus a universal fallback.

## Conscrypt has to stay

Worth recording, because it looks removable and isn't. Nothing in the app references it, and `SslUtils.getSslContext()` falls back cleanly to the platform TLS provider — but pairing derives the SPAKE2 secret from the **TLS exporter**, and `PairingConnectionCtx.exportKeyingMaterial()` has a *separate* fallback to `com.android.org.conscrypt.Conscrypt`. That's a hidden platform class, so the lookup is blocked on Android 11+ and pairing fails **with a correct code** — the handshake succeeds and the key derivation fails right after. libadb calls it "recommended"; for pairing it's required, and the dependency now says so.

## Two bugs this surfaced

**The `sun.security` keep rule matched nothing.** `sun-security-android` repackages to `android.sun.security.*`. Harmless while minification was off; with R8 on it would have broken ADB key generation *at runtime, not at build time*, since `OIDMap`, `CertificateExtensions` and `X509Key` resolve extension classes via `Class.forName`.

**`UpdateChecker` took the first `.apk` asset in the release.** With one APK per ABI in both a main and a `-dev` flavour that's eight lookalike assets, so it could hand an arm64 phone the x86_64 build, or move a release user onto the dev channel — the latter was already possible today. It now walks `Build.SUPPORTED_ABIS` in the device's own preference order within the matching channel, falling back to universal and then to a single unsuffixed asset, so **upgrading from a pre-split release still resolves**. The release workflow stages APKs under the names that selection depends on.

## Testing

- 9 new unit tests on asset selection, including the pre-split-release and unknown-ABI fallbacks; 20 pass total.
- Verified in the R8 mapping that `org.conscrypt.Conscrypt`, `exportKeyingMaterial(SSLSocket, String, byte[], int)`, `OpenSSLProvider`'s constructor and the 145 `android.sun.security` classes all survive unrenamed.
- **Pairing and install confirmed on-device against the minified arm64 release split** — the build users actually get, which exercises both the Conscrypt keep rules and the certificate-generation fix.

## Note for reviewers

README and `docs/index.html` now tell users which file to take instead of "download `anyapk.apk`". The in-app updater handles the choice automatically after the first install.