### PR TITLE
Stage release APKs from unsplit builds too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,20 @@ jobs:
           # One APK per ABI plus the universal fallback. UpdateChecker.selectAsset()
           # matches on the trailing -<abi>.apk, so the suffix here is load-bearing:
           # renaming these silently breaks in-app updates.
+          # A branch that predates the ABI split emits a single app-release.apk instead.
+          # That build carries every ABI, so it is the universal one by definition. The
+          # dev variant builds from the dev branch rather than from the tag, so it lags
+          # main by design and this is a normal state, not a failure.
           shopt -s nullglob
           staged=0
-          for src in app/build/outputs/apk/release/app-*-release.apk; do
+          for src in app/build/outputs/apk/release/app-*-release.apk \
+                     app/build/outputs/apk/release/app-release.apk; do
+            # app-release.apk is a literal, not a pattern, so nullglob does not drop it
+            # when the build did produce splits.
+            [ -f "$src" ] || continue
             case "$src" in *-unsigned*) continue;; esac
-            abi=$(basename "$src"); abi=${abi#app-}; abi=${abi%-release.apk}
+            abi=$(basename "$src"); abi=${abi#app-}; abi=${abi%release.apk}
+            abi=${abi%-}; abi=${abi:-universal}
             cp "$src" "release/anyapk${{ matrix.suffix }}-${{ needs.version.outputs.version }}-${abi}.apk"
             staged=$((staged + 1))
           done


### PR DESCRIPTION
Blocks tagging v0.0.15 — without this the release workflow fails and publishes nothing.

The release builds two variants: `main` from the tag, and `-dev` from the `dev` branch. `dev` is currently 18 commits behind and still has `isMinifyEnabled = false` with no ABI splits, so its build emits a single `app-release.apk`. Actions takes the *workflow* from the tag but checks out `dev` for that variant's *code*, so #82's staging glob `app-*-release.apk` found nothing, tripped the "no APKs produced" guard, and failed the job — and the `release` job `needs: build`, so no release would be published at all.

An unsplit build contains every ABI, so it's staged as `-universal`. `UpdateChecker.selectAsset()` already falls back to universal, so a dev user on an unsplit build still resolves correctly.

Also fixes a second bug in the same loop: `app-release.apk` is a literal, not a pattern, so `nullglob` doesn't drop it when the build *did* produce splits — `cp` would then fail the main build under `set -e`. Guarded with `[ -f "$src" ]`.

Verified by running the staging loop against three fixtures — a split build, an unsplit build, and an empty directory:

```
== split ==     anyapk-0.0.15-{arm64-v8a,armeabi-v7a,x86_64,universal}.apk   exit=0
== unsplit ==   anyapk-dev-0.0.15-universal.apk                              exit=0
== empty ==     ERROR: none staged                                           exit=nonzero
```

Worth considering separately: merging `main` into `dev` so the dev channel also gets the size reduction. This change makes the release robust either way.