### PR TITLE
Retire the dev branch and rescue the two fixes only it had

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,28 +43,18 @@ jobs:
   build:
     needs: version
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # The release build comes from the tag itself, not from whatever main has
-          # moved on to since.
-          - variant: main
-            ref: ${{ github.ref_name }}
-            suffix: ""
-          - variant: dev
-            ref: dev
-            suffix: "-dev"
     steps:
+      # The release build comes from the tag itself, not from whatever main has
+      # moved on to since.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.ref }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 1
 
       - name: Align version for build
         run: |
           set -euo pipefail
-          version="${{ needs.version.outputs.version }}${{ matrix.suffix }}"
+          version="${{ needs.version.outputs.version }}"
           code="${{ needs.version.outputs.versionCode }}"
           sed -i -E "s/(versionName\s*=\s*)\"[^\"]+\"/\1\"${version}\"/" app/build.gradle.kts
           sed -i -E "s/(versionCode\s*=\s*)[0-9]+/\1${code}/" app/build.gradle.kts
@@ -108,10 +98,9 @@ jobs:
           # One APK per ABI plus the universal fallback. UpdateChecker.selectAsset()
           # matches on the trailing -<abi>.apk, so the suffix here is load-bearing:
           # renaming these silently breaks in-app updates.
-          # A branch that predates the ABI split emits a single app-release.apk instead.
-          # That build carries every ABI, so it is the universal one by definition. The
-          # dev variant builds from the dev branch rather than from the tag, so it lags
-          # main by design and this is a normal state, not a failure.
+          # A commit that predates the ABI split emits a single app-release.apk instead,
+          # which carries every ABI and so is the universal one by definition. Kept so
+          # that tagging an older commit degrades gracefully rather than failing here.
           shopt -s nullglob
           staged=0
           for src in app/build/outputs/apk/release/app-*-release.apk \
@@ -122,7 +111,7 @@ jobs:
             case "$src" in *-unsigned*) continue;; esac
             abi=$(basename "$src"); abi=${abi#app-}; abi=${abi%release.apk}
             abi=${abi%-}; abi=${abi:-universal}
-            cp "$src" "release/anyapk${{ matrix.suffix }}-${{ needs.version.outputs.version }}-${abi}.apk"
+            cp "$src" "release/anyapk-${{ needs.version.outputs.version }}-${abi}.apk"
             staged=$((staged + 1))
           done
           if [ "$staged" -eq 0 ]; then
@@ -133,7 +122,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: apk-${{ matrix.variant }}
+          name: apk
           path: release/*.apk
           retention-days: 7
           if-no-files-found: error
@@ -146,16 +135,10 @@ jobs:
     needs: [version, build]
     runs-on: ubuntu-latest
     steps:
-      - name: Download main APK
+      - name: Download APKs
         uses: actions/download-artifact@v4
         with:
-          name: apk-main
-          path: release
-
-      - name: Download dev APK
-        uses: actions/download-artifact@v4
-        with:
-          name: apk-dev
+          name: apk
           path: release
 
       - name: Create GitHub release
@@ -168,4 +151,3 @@ jobs:
           generate_release_notes: true
           files: |
             release/anyapk-${{ needs.version.outputs.version }}-*.apk
-            release/anyapk-dev-${{ needs.version.outputs.version }}-*.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,13 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    dependenciesInfo {
+        // Google-encrypted dependency blob; only Google can read it. Strip
+        // it so IzzyOnDroid/F-Droid scanners don't flag an opaque signing block.
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/anyapk/installer/AdbInstaller.kt
+++ b/app/src/main/java/com/anyapk/installer/AdbInstaller.kt
@@ -276,8 +276,9 @@ object AdbInstaller {
             val apkFile = java.io.File(apkPath)
             val apkSize = apkFile.length()
 
-            // Open install stream with size
-            stream = manager.openStream("exec:cmd package install ${bypassFlag()}-S $apkSize")
+            // Open install stream with size. `-d` allows downgrading to an older
+            // versionCode; for fresh installs and upgrades it's a no-op.
+            stream = manager.openStream("exec:cmd package install -d ${bypassFlag()}-S $apkSize")
 
             // Stream the APK data
             val outputStream = stream.openOutputStream()
@@ -379,7 +380,7 @@ object AdbInstaller {
             }
 
             val totalSize = sources.sumOf { it.size }
-            val created = runExec(manager, "cmd package install-create -r ${bypassFlag()}-S $totalSize")
+            val created = runExec(manager, "cmd package install-create -r -d ${bypassFlag()}-S $totalSize")
             sessionId = SESSION_ID.find(created)?.groupValues?.get(1)
                 ?: return@withContext Result.failure(
                     Exception(created.ifEmpty { "The package manager refused to open an install session" })


### PR DESCRIPTION
Releases come from tags now, so the second build from a long-lived `dev` branch has nothing left to do. The `build` job drops its matrix and always builds the tag; the `release` job attaches one set of APKs.

## Two fixes were about to be lost

`dev` had six commits not on `main`, and two of them are real fixes whose issues were **closed on the strength of a dev build** — so neither has ever shipped in a release:

- **`-d` to allow downgrading an APK to an older versionCode** (#58). Ported onto the `bypassFlag()` helper `main` refactored out since. I also extended it to `install-create`, which `main` gained afterwards with bundle support and which would otherwise still refuse a downgrade for `.apks`/`.xapk` bundles.
- **Strip `DEPENDENCY_INFO_BLOCK`** (#47), the Google-encrypted dependency blob, so IzzyOnDroid and F-Droid scanners don't flag an opaque signing block.

The remaining four are already on `main` by other routes or are obsolete: the PolinRider malware removal landed as `50f0c18`, `USAGE.md` was folded into the README, and the rest are a README wording tweak and a `.gitignore` line.

Merging `dev` outright wasn't viable — it conflicted in `.gitignore`, `README.md`, `AdbInstaller.kt`, plus a modify/delete on `USAGE.md` — and would have dragged obsolete content back. Cherry-picking the two that matter is cleaner.

## Note on the updater

`UpdateChecker` keeps its `-dev` channel filter. v0.0.15 shipped `anyapk-dev-0.0.15-universal.apk` before this change, so the filter still has something to exclude for anyone updating to it.

## Verified

Builds and passes all 20 unit tests. Workflow YAML parses; no `matrix`, `apk-dev`, or `anyapk-dev` references remain, and no docs referenced the dev channel.

**Before deleting the branch**, `dev` tip is `0b832de` — recoverable from that SHA if anything here was misjudged.