### PR TITLE
Stop claiming pairing survives a reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Anyapk is not a solution to the problem - it's a tool that helps you bypass the 
 
 ## Features
 
-- **One-time setup**: Pair once using wireless debugging, use forever
+- **One-time pairing**: Pair once using wireless debugging — no need to re-pair after reboots (you'll just need to re-enable wireless debugging itself, since Android turns it off on reboot)
 - **Pair from the notification shade**: Reply to a notification with the pairing code — no split-screen gymnastics
 - **No root required**: Uses Android's built-in wireless ADB
 - **No external dependencies**: Everything runs locally on your device
@@ -145,7 +145,9 @@ If you can't install the APK directly (due to existing restrictions), use ADB fr
 
 6. Approve the **"Allow USB debugging?"** prompt — check **"Always allow from this computer"** and tap **Allow**. If no prompt appears, tap **Test Connection** in anyapk to trigger it.
 
-That's it! anyapk is now permanently connected and ready to use.
+That's it! anyapk is paired and ready to use.
+
+> **Note on persistence:** Android turns **Wireless debugging** off automatically when the device reboots. After a reboot, just flip it back on in Developer Options — you won't need to re-pair, since anyapk stays in the **Paired devices** list. If anyapk goes unused for a long stretch, Android may also drop it from that list; if that happens, repeat the pairing steps above.
 
 ### Installing APK Files
 
@@ -236,7 +238,7 @@ Your activity is your business, not ours.
 ## Troubleshooting
 
 **"Setup Required" stays visible even after enabling wireless debugging:**
-- Make sure wireless debugging is actually ON in Developer Options
+- Make sure wireless debugging is actually ON in Developer Options (it gets turned off automatically on every reboot)
 - Try restarting anyapk
 - Verify you're on WiFi (wireless debugging requires WiFi)
 


### PR DESCRIPTION
Ported from `dev` (`f5099ce`) before that branch goes away.

`main` currently says:

> - **One-time setup**: Pair once using wireless debugging, use forever

and

> That's it! anyapk is now permanently connected and ready to use.

Neither is true. Android turns **Wireless debugging** off on every reboot. The *pairing* does persist — anyapk stays in the Paired devices list — but the toggle doesn't, so users hit "Setup Required" after a reboot and reasonably conclude the pairing broke. The README now separates those two things and the troubleshooting entry says the toggle resets on reboot.

I classified this as a "README wording tweak" when I triaged the dev branch in #84 and set it aside. That was wrong — it corrects a claim about the app that isn't accurate, which is worth more than the two code fixes I did port.

Last of the salvage from `dev`. The remaining two commits there really are redundant: `.DS_Store` is already in `main`'s `.gitignore`, and the `USAGE.md` update targets a file `main` folded into the README.